### PR TITLE
Fixed division by zero error

### DIFF
--- a/newsroom/analyze/rouge/ROUGE-1.5.5/ROUGE-1.5.5.pl
+++ b/newsroom/analyze/rouge/ROUGE-1.5.5/ROUGE-1.5.5.pl
@@ -2451,6 +2451,9 @@ sub wlcs {
       }
     }
   }
+  if($$base==0) {
+      $$base=1e-8;
+  }
   $$score=wlcsWeightInverse($$hit/$$base,$weightFactor);
 }
 


### PR DESCRIPTION
Fixed this error:
    Illegal division by zero at ROUGE-1.5.5.pl line 2454.

The error occurred when ROUGE-1.5.5.pl tried to calculate the ROUGE-W-1.2 scores for some valid system output on the Newsroom test set. 